### PR TITLE
feat: gnuplot

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -30,6 +30,7 @@ apk --no-cache add \
   fontconfig \
   ghostscript \
   gnupg \
+  gnuplot \
   git \
   graphviz \
   make \


### PR DESCRIPTION
Add `gnuplot` in the "Install system packages" section.
TikZ LaTex package for certain plot (like functions) needs gnuplot software installed.